### PR TITLE
translation: navbar adjustment

### DIFF
--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -8,7 +8,7 @@
     "description": "Navbar item with label Main site"
   },
   "item.label.Join Discord": {
-    "message": "加入讨论区",
+    "message": "加入Discord",
     "description": "Navbar item with label Join Discord"
   },
   "item.label.GitHub": {


### PR DESCRIPTION
11 "message": "加入Discord"

Since we have a forum"讨论区"

which would cause ambiguity and there is no Chinese name for Discord